### PR TITLE
Fix documentation for editor vim plugin ALE

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -153,7 +153,7 @@ extension for [coc.nvim](https://github.com/neoclide/coc.nvim).
 " Linter
 let g:ale_linters = { "python": ["ruff"] }
 " Formatter
-let g:ale_fixers = { "python": ["ruff-format"] }
+let g:ale_fixers = { "python": ["ruff_format"] }
 ```
 
 </details>


### PR DESCRIPTION
The documented configuration did not work. On failure, ALE suggest to
run `ALEFixSuggest`, into with it documents the working configuration key

'ruff_format' - Fix python files with the ruff formatter.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
